### PR TITLE
Fix 'variable is referenced before assignment' error

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -422,6 +422,7 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
     indent_chances = {}
     last_indent = tokens[0][2]
     visual_indent = None
+    last_token_multiline = False
     # for each depth, memorize the visual indent column
     indent = [last_indent[1]]
     if verbose >= 3:

--- a/pep8.py
+++ b/pep8.py
@@ -886,7 +886,7 @@ def explicit_line_join(logical_line, tokens):
     Okay: aaa = ("bbb "\n       "ccc")
     Okay: aaa = "bbb " \\n    "ccc"
     """
-    prev_start = prev_end = parens = 0
+    prev_start = prev_end = parens = backslash = 0
     for token_type, text, start, end, line in tokens:
         if start[0] != prev_start and parens and backslash:
             yield backslash, "E502 the backslash is redundant between brackets"


### PR DESCRIPTION
I think it is just mistype. It's works well without this small fix, but looks a little bit ugly.