### PR TITLE
allow use # noqa to disable E721 warning

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -323,7 +323,7 @@ This is the current list of error and warning codes:
 +----------+----------------------------------------------------------------------+
 | E714     | test for object identity should be 'is not'                          |
 +----------+----------------------------------------------------------------------+
-| E721     | do not compare types, use 'isinstance()'                             |
+| E721 (^) | do not compare types, use 'isinstance()'                             |
 +----------+----------------------------------------------------------------------+
 | E731     | do not assign a lambda expression, use a def                         |
 +----------+----------------------------------------------------------------------+

--- a/pep8.py
+++ b/pep8.py
@@ -974,7 +974,7 @@ def comparison_negative(logical_line):
             yield pos, "E714 test for object identity should be 'is not'"
 
 
-def comparison_type(logical_line):
+def comparison_type(logical_line, noqa):
     r"""Object type comparisons should always use isinstance().
 
     Do not compare types directly.
@@ -990,7 +990,7 @@ def comparison_type(logical_line):
     Okay: if type(a1) is type(b1):
     """
     match = COMPARE_TYPE_REGEX.search(logical_line)
-    if match:
+    if match and not noqa:
         inst = match.group(1)
         if inst and isidentifier(inst) and inst not in SINGLETONS:
             return  # Allow comparison for types which are not obvious


### PR DESCRIPTION
Sometimes `isinstance()` is not suitable for comparing types.  For
example, someone may want to make sure an object is exact instance of a
type, not instance of its subclasses.

This patch allows to use `# noqa` comment to disable warning in this case.