### PR TITLE
remove EOL with backslash

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1282,7 +1282,7 @@ def normalize_paths(value, parent=os.curdir):
         return value
     paths = []
     for path in value.split(','):
-        path = path.strip()
+        path = path.strip().strip('\\\r\n')
         if '/' in path:
             path = os.path.abspath(os.path.join(parent, path))
         paths.append(path.rstrip('/'))


### PR DESCRIPTION
I found a flake8 problem. When i use exclude with a long long excluded files. i need make the long commands split over multiple lines. like this:

```python
flake8 --ignore=E501,F403,E265,F812 --exclude='test1.py, \
test2.py' 
```

options.exclude is ['test1.py', '\\ntest2.py']

It's not correct

[flake8#31](https://gitlab.com/pycqa/flake8/merge_requests/31). @sigmavirus24 think should be here to solve